### PR TITLE
Update the plugin documentation to Read the Docs

### DIFF
--- a/website/ninja_web/plugins/templates/plugins.html
+++ b/website/ninja_web/plugins/templates/plugins.html
@@ -81,7 +81,7 @@
 
     <div class="section right small-width" id="submit-banner">
       <h1>Plugins submitions</h1>
-      <a class="link-web" href="http://code.google.com/p/ninja-ide/wiki/Plugins_Tutorial">Learn how to write a plugin</a>
+      <a class="link-web" href="http://ninja-ide.readthedocs.org/en/latest/">Learn how to write a plugin</a>
       <a class="link-web" href="{% url plugin_submit %}">Submit your plugin!</a>
     </div>
 


### PR DESCRIPTION
Currently the documentation on Google is still mentioned. 
This is changed to the version on Read the Docs.
